### PR TITLE
Fix: Steam and MSStore aren't displayed in error message

### DIFF
--- a/wingetui/uiSections.py
+++ b/wingetui/uiSections.py
@@ -1438,7 +1438,7 @@ class UninstallSoftwareSection(QWidget):
                         "mainTitle": _("Unable to load informarion"),
                         "mainText": _("We could not load detailed information about this package, because it was not installed neither from Winget nor Scoop."),
                         "buttonTitle": _("Ok"),
-                        "errorDetails": _(f"Uninstallable packages with the origin listed as \"{item.text(4)}\" are not published on any package manager, so there's no information available to show about them."),
+                        "errorDetails": _("Uninstallable packages with the origin listed as \"{0}\" are not published on any package manager, so there's no information available to show about them.").format(item.text(4)),
                         "icon": QIcon(getMedia("notif_warn")),
                     }
                 self.err.showErrorMessage(errorData, showNotification=False)

--- a/wingetui/uiSections.py
+++ b/wingetui/uiSections.py
@@ -1438,7 +1438,7 @@ class UninstallSoftwareSection(QWidget):
                         "mainTitle": _("Unable to load informarion"),
                         "mainText": _("We could not load detailed information about this package, because it was not installed neither from Winget nor Scoop."),
                         "buttonTitle": _("Ok"),
-                        "errorDetails": _("Uninstallable packages with the origin listed as \"Local PC\" are not published on any package manager, so there's no information available to show about them."),
+                        "errorDetails": _(f"Uninstallable packages with the origin listed as \"{item.text(4)}\" are not published on any package manager, so there's no information available to show about them."),
                         "icon": QIcon(getMedia("notif_warn")),
                     }
                 self.err.showErrorMessage(errorData, showNotification=False)


### PR DESCRIPTION
instead of showing only "Local PC", using f-string allows "Steam" and "MSStore" as well. I'm not sure, though, if it would be better to have a custom message for MSStore

![Captura de tela 2022-12-30 113644](https://user-images.githubusercontent.com/73800734/210082143-60a03c48-b63a-417d-a9f7-7eb342206473.png)
![change to winget and scoop](https://user-images.githubusercontent.com/73800734/210082147-d6035e85-cfe4-4c30-afb3-28792ebfe5e9.png)
![Captura de tela 2022-12-30 113625](https://user-images.githubusercontent.com/73800734/210082149-0b27750e-ad9e-4086-a451-ff02831c345d.png)
