### PR TITLE
Unified translation strings for package managers

### DIFF
--- a/wingetui/__init__.py
+++ b/wingetui/__init__.py
@@ -178,13 +178,13 @@ try:
 
         def detectWinget(self):
             try:
-                self.callInMain.emit(lambda: self.loadingText.setText(_("Locating Winget...")))
+                self.callInMain.emit(lambda: self.loadingText.setText(_("Locating {pm}...").format(pm = "Winget")))
                 o = subprocess.run(f"{wingetHelpers.winget} -v", shell=True, stdout=subprocess.PIPE)
                 print(o.stdout)
                 print(o.stderr)
                 globals.componentStatus["wingetFound"] = o.returncode == 0
                 globals.componentStatus["wingetVersion"] = o.stdout.decode('utf-8').replace("\n", "")
-                self.callInMain.emit(lambda: self.loadingText.setText(_("Winget found: {0}").format(globals.componentStatus['wingetFound'])))
+                self.callInMain.emit(lambda: self.loadingText.setText(_("{pm} found: {state}").format(pm = "Winget", state = globals.componentStatus['wingetFound'])))
             except Exception as e:
                 print(e)
             self.loadStatus += 1
@@ -200,26 +200,26 @@ try:
             
         def detectChocolatey(self):
             try:
-                self.callInMain.emit(lambda: self.loadingText.setText(_("Locating Chocolatey...")))
+                self.callInMain.emit(lambda: self.loadingText.setText(_("Locating {pm}...").format(pm = "Chocolatey")))
                 o = subprocess.run(f"{chocoHelpers.choco} -v", shell=True, stdout=subprocess.PIPE)
                 print(o.stdout)
                 print(o.stderr)
                 globals.componentStatus["chocoFound"] = o.returncode == 0
                 globals.componentStatus["chocoVersion"] = o.stdout.decode('utf-8').replace("\n", "")
-                self.callInMain.emit(lambda: self.loadingText.setText(_("Chocolatey found: {0}").format(globals.componentStatus['chocoFound'])))
+                self.callInMain.emit(lambda: self.loadingText.setText(_("{pm} found: {state}").format(pm = "Chocolatey", state = globals.componentStatus['chocoFound'])))
             except Exception as e:
                 print(e)
             self.loadStatus += 1
             
         def detectScoop(self):
             try:
-                self.callInMain.emit(lambda: self.loadingText.setText(_("Locating Scoop...")))
+                self.callInMain.emit(lambda: self.loadingText.setText(_("Locating {pm}...").format(pm = "Scoop")))
                 o = subprocess.run(f"{scoopHelpers.scoop} -v", shell=True, stdout=subprocess.PIPE)
                 print(o.stdout)
                 print(o.stderr)
                 globals.componentStatus["scoopFound"] = o.returncode == 0
                 globals.componentStatus["scoopVersion"] = o.stdout.decode('utf-8').split("\n")[1]
-                self.callInMain.emit(lambda: self.loadingText.setText(_("Scoop found: {0}").format(globals.componentStatus['scoopFound'])))
+                self.callInMain.emit(lambda: self.loadingText.setText(_("{pm} found: {state}").format(pm = "Scoop", state = globals.componentStatus['scoopFound'])))
             except Exception as e:
                 print(e)
             self.loadStatus += 1
@@ -249,11 +249,11 @@ try:
         def detectSudo(self):
             global sudoLocation
             try:
-                self.callInMain.emit(lambda: self.loadingText.setText(_("Locating sudo...")))
+                self.callInMain.emit(lambda: self.loadingText.setText(_("Locating {pm}...").format(pm = "sudo")))
                 o = subprocess.run(f"{sudoPath} -v", shell=True, stdout=subprocess.PIPE)
                 globals.componentStatus["sudoFound"] = o.returncode == 0
                 globals.componentStatus["sudoVersion"] = o.stdout.decode('utf-8').split("\n")[0]
-                self.callInMain.emit(lambda: self.loadingText.setText(_("Sudo found: {0}").format(globals.componentStatus['sudoFound'])))
+                self.callInMain.emit(lambda: self.loadingText.setText(_("{pm} found: {state}").format(pm = "Sudo", state = globals.componentStatus['sudoFound'])))
             except Exception as e:
                 print(e)
             self.loadStatus += 1

--- a/wingetui/uiSections.py
+++ b/wingetui/uiSections.py
@@ -2492,9 +2492,9 @@ class SettingsSection(QScrollArea):
         self.layout.addWidget(title)
         self.layout.addSpacing(20)
 
-        self.wingetPreferences = QSettingsTitle(_("Winget preferences"), getMedia("winget"), _("Winget package manager specific preferences"))
+        self.wingetPreferences = QSettingsTitle(_("{pm} preferences").format(pm = "Winget"), getMedia("winget"), _("{pm} package manager specific preferences").format(pm = "Winget"))
         self.layout.addWidget(self.wingetPreferences)
-        disableWinget = QSettingsCheckBox(_("Enable Winget"))
+        disableWinget = QSettingsCheckBox(_("Enable {pm}").format(pm = "Winget"))
         disableWinget.setChecked(not getSettings("DisableWinget"))
         disableWinget.stateChanged.connect(lambda v: (setSettings("DisableWinget", not bool(v)), parallelInstalls.setEnabled(v), button.setEnabled(v), enableSystemWinget.setEnabled(v)))
         self.wingetPreferences.addWidget(disableWinget)
@@ -2513,10 +2513,10 @@ class SettingsSection(QScrollArea):
         enableSystemWinget.setEnabled(disableWinget.isChecked())
 
         
-        self.scoopPreferences = QSettingsTitle(_("Scoop preferences"), getMedia("scoop"), _("Scoop package manager specific preferences"))
+        self.scoopPreferences = QSettingsTitle(_("{pm} preferences").format(pm = "Scoop"), getMedia("scoop"), _("{pm} package manager specific preferences").format(pm = "Scoop"))
         self.layout.addWidget(self.scoopPreferences)
 
-        disableScoop = QSettingsCheckBox(_("Enable Scoop"))
+        disableScoop = QSettingsCheckBox(_("Enable {pm}").format(pm = "Scoop"))
         disableScoop.setChecked(not getSettings("DisableScoop"))
         disableScoop.stateChanged.connect(lambda v: (setSettings("DisableScoop", not bool(v)), scoopPreventCaps.setEnabled(v), bucketManager.setEnabled(v), uninstallScoop.setEnabled(v), enableScoopCleanup.setEnabled(v)))
         self.scoopPreferences.addWidget(disableScoop)
@@ -2540,9 +2540,9 @@ class SettingsSection(QScrollArea):
         uninstallScoop.setEnabled(disableScoop.isChecked())
         enableScoopCleanup.setEnabled(disableScoop.isChecked())
         
-        self.chocoPreferences = QSettingsTitle(_("Chocolatey preferences"), getMedia("choco"), _("Chocolatey package manager specific preferences"))
+        self.chocoPreferences = QSettingsTitle(_("{pm} preferences").format(pm = "Chocolatey"), getMedia("choco"), _("{pm} package manager specific preferences").format(pm = "Chocolatey"))
         self.layout.addWidget(self.chocoPreferences)
-        disableChocolatey = QSettingsCheckBox(_("Enable Choclatey"))
+        disableChocolatey = QSettingsCheckBox(_("Enable {pm}").format(pm = "Chocolatey"))
         disableChocolatey.setChecked(not getSettings("DisableChocolatey"))
         disableChocolatey.stateChanged.connect(lambda v: (setSettings("DisableChocolatey", not bool(v))))
         self.chocoPreferences.addWidget(disableChocolatey)


### PR DESCRIPTION
Unified translation string for pacakge managers, like:
- Locating {pm}...
- {pm} found: {state}
- {pm} preferences
- {pm} package manager specific preferences
- Enable {pm}

{pm} (package manager) = Winget/Scoop/Chocolatey ...maybe is good write as notice to Toolge
{state} = True/False

More untranslated strings:
- Chocolatey packages are being loaded. Since this is the first time, it might take a while, and they will show here once loaded.
- Blacklist packages
- Show Scoop packages in lowercase
- Local PC