### PR TITLE
Use MS Yahei for Chinese Simplified

### DIFF
--- a/wingetui/tools.py
+++ b/wingetui/tools.py
@@ -415,7 +415,12 @@ except Exception as e:
 
 langName = lang['locale']
 
-if "zh" in langName:
+if "zh_CN" in langName:
+    globals.textfont: str = "Microsoft YaHei UI"
+    globals.dispfont: str = "Microsoft YaHei UI"
+    globals.dispfontsemib: str = "Microsoft YaHei UI"
+
+if "zh_TW" in langName:
     globals.textfont: str = "Microsoft JhengHei UI"
     globals.dispfont: str = "Microsoft JhengHei UI"
     globals.dispfontsemib: str = "Microsoft JhengHei UI"


### PR DESCRIPTION
CJK characters have different forms in different Chinese variations. The current version uses Microsoft JhengHei UI for all Chinese variations, a font intended to be used in Traditional Chinese. Using Microsoft YaHei UI to display Simplified Chinese characters it's more accurate.

![image](https://user-images.githubusercontent.com/16105768/218317247-31d3c151-69b7-4cfa-8958-154c400ced43.png)
Current
![image](https://user-images.githubusercontent.com/16105768/218317269-4e29f026-6299-44c8-a79c-ddbb294f31ea.png)
Using MSYH