### PR TITLE
Use translation for "Latest" in Version combo

### DIFF
--- a/wingetui/storeEngine.py
+++ b/wingetui/storeEngine.py
@@ -1144,7 +1144,7 @@ class PackageInfoPopupWindow(QWidget):
             while self.versionCombo.count()>0:
                 self.versionCombo.removeItem(0)
             try:
-                self.versionCombo.addItems(["Latest"] + appInfo["versions"])
+                self.versionCombo.addItems([_("Latest")] + appInfo["versions"])
             except KeyError:
                 pass
             if "…" in self.givenPackageId:


### PR DESCRIPTION
"Latest" wasn't displayed with the translation in other languages.

Before:
![image](https://user-images.githubusercontent.com/71824258/219954376-d1c4efd6-ca42-463b-81b4-4ea5fea22b58.png)

After:
![image](https://user-images.githubusercontent.com/71824258/219954436-f7e4848b-66c2-49dd-bd7c-59f85610d959.png)
