### PR TITLE
Draft: Check translations

### DIFF
--- a/.github/workflows/update-tolgee.yml
+++ b/.github/workflows/update-tolgee.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Download Tolgee translations
         run: |
           python scripts/download_translations.py --autocommit
+      - name: Check translations
+        run: |
+          python scripts/export_translation_strings.py
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
@@ -25,3 +28,4 @@ jobs:
           author: "Tolgee Bot <tolgee-bot@users.noreply.github.com>"
           commit-message: "Update translations from Tolgee"
           branch: pull-request/update-translation
+#          body-path: 

--- a/scripts/create_translations.py
+++ b/scripts/create_translations.py
@@ -1,0 +1,71 @@
+import argparse
+import tolgee_requests
+import translation_utils
+import json
+from time import sleep
+
+
+__parser = argparse.ArgumentParser()
+__parser.add_argument("--export-all", help="Export not used and not translated strings", action="store_true")
+__parser.add_argument("--print-only", help="Print not translated strings", action="store_true")
+__args = __parser.parse_args()
+
+
+def encode_str(str: str, strip = 0):
+    new_str = str
+    if strip > 0:
+        new_str = str[:strip].strip()
+    return new_str.encode("utf-8")
+
+
+def upload(strs: list[str]):
+    count = len(strs)
+    i = 1
+    for key in strs:
+        print("[{num}/{count}] Uploading key... ".format(num=i, count=count))
+        print(encode_str(key, strip=100), "... ", end="")
+        response = tolgee_requests.create_key(key)
+        if (not response.ok):
+            print("Failed")
+            print("Error", response.status_code, response.text)
+            return
+        else:
+            print("Ok")
+        sleep(0.150)
+        i += 1
+    print("Done")
+
+
+def print_only(strs: list[str]):
+    for key in strs:
+        print(encode_str(key))
+
+
+def __export():
+    f = open("../lang_compare.json", "w", encoding="utf-8")
+    output = translation_utils.compare_strings()
+    json.dump(output, f, ensure_ascii=False, indent="  ")
+    f.close()
+
+
+def __init__():
+    strs = translation_utils.compare_strings()
+    key_name = "not_translated"
+    if key_name in strs:
+        stringsFound = len(strs[key_name])
+        print("Found not translated strings: {count}".format(count=stringsFound))
+        if stringsFound > 0:
+            if __args.print_only:
+                print_only(strs[key_name])
+            else:
+                sleep(1)
+                upload(strs[key_name])
+    else:
+        print(f"Key '{key_name}' missing")
+
+
+if (__args.export_all):
+    __export()
+    exit()
+
+__init__()

--- a/scripts/download_translations.py
+++ b/scripts/download_translations.py
@@ -2,17 +2,7 @@ import sys
 import json
 import os
 import time
-
-try:
-    with open("APIKEY.txt", "r") as f:
-        apikey = f.read().strip()
-        if not apikey:
-            raise ValueError("APIKEY.txt is empty")
-        print("API key found in APIKEY.txt")
-except FileNotFoundError:
-    apikey = os.environ.get("TOLGEE_KEY", "")
-    if not apikey:
-        apikey = input("Write api key and press enter: ")
+import tolgee_requests
 
 os.chdir(os.path.dirname(__file__) + "/..") # move to root project
 
@@ -36,13 +26,6 @@ if len(sys.argv)>1:
         print(sys.argv[1])
 
 
-apiurl = f"https://app.tolgee.io/v2/projects/1205/export?format=JSON&structureDelimiter=&filterState=UNTRANSLATED&filterState=TRANSLATED&filterState=REVIEWED&zip=true"
-
-try:
-    import requests
-except ImportError:
-    os.system("pip install requests")
-    import requests
 import glob, zipfile
 
 os.chdir("wingetui/lang")
@@ -53,7 +36,7 @@ print()
 print("  Downloading updated translations...")
 
 
-response = requests.get(apiurl, headers={"X-API-Key": apikey})
+response = tolgee_requests.export()
 if (not response.ok):
     statusCode = response.status_code
     print(f"  Error {statusCode}: {response.text}")

--- a/scripts/tolgee_requests.py
+++ b/scripts/tolgee_requests.py
@@ -1,0 +1,39 @@
+import os
+try:
+    import requests
+except ImportError:
+    os.system("pip install requests")
+    import requests
+
+
+__project_id = 1205 # wingetui
+__api_url = f"https://app.tolgee.io/v2/projects/{__project_id}"
+__api_key = ""
+
+
+try:
+    with open("APIKEY.txt", "r") as f:
+        __api_key = f.read().strip()
+        if not __api_key:
+            raise ValueError("APIKEY.txt is empty")
+        # print("API key found in APIKEY.txt")
+except FileNotFoundError:
+    __api_key = os.environ.get("TOLGEE_KEY", "")
+    if not __api_key:
+        __api_key = input("Write api key and press enter: ")
+
+
+def export(format = "JSON", zip = True):
+    isZip = "true" if zip else "false"
+    url = f"{__api_url}/export?format={format}&structureDelimiter=&filterState=UNTRANSLATED&filterState=TRANSLATED&filterState=REVIEWED&zip={isZip}"
+    response = requests.get(url, headers={"X-API-Key": __api_key})
+    return response
+
+
+def create_key(key):
+    url = f"{__api_url}/keys/create"
+    json: dict[str, str] = {
+        "name": key
+    }
+    response = requests.post(url, headers={"X-API-Key": __api_key}, json=json)
+    return response

--- a/scripts/translation_utils.py
+++ b/scripts/translation_utils.py
@@ -1,0 +1,59 @@
+import os
+import re
+import json
+
+
+os.chdir(os.path.dirname(__file__) + "/..") # move to root project
+os.chdir("wingetui")
+
+
+# Function to remove special characters from a string
+def remove_special_chars(string):
+    # Regular expression for special characters (excluding letters and digits)
+    special_chars = r'[^a-zA-Z0-9]'
+    # Use regular expression to remove special characters from the string
+    return re.sub(special_chars, '', string)
+
+
+def get_all_strings():
+    regex = r'(?<=_\(["\']).+?(?=["\']\))'
+    translation_strings: list[str] = []
+
+    for (dirpath, _dirnames, filenames) in os.walk(".", topdown=True):
+        for file in filenames:
+            _file_name, file_ext = os.path.splitext(file)
+            if (file_ext != ".py"):
+                continue
+            f = open(os.path.join(dirpath, file), "r", encoding="utf-8")
+            matches: list[str] = re.findall(regex, f.read())
+            for match in matches:
+                translation_strings.append(match.encode('raw_unicode_escape').decode('unicode_escape'))
+            f.close()
+
+    translation_strings = list(set(translation_strings)) # uniq
+    translation_strings.sort(key=lambda x: (remove_special_chars(x.lower()), x))
+    return translation_strings
+
+
+def get_all_translations(lang = "en"):
+    f = open(f"lang/lang_{lang}.json", "r", encoding="utf-8")
+    lang_strings: dict[str, str] = json.load(f)
+    f.close()
+    return lang_strings
+
+
+def compare_strings():
+    not_used: list[str] = []
+    translation_obj: dict[str, str] = {}
+    lang_strings = get_all_translations()
+    for key in get_all_strings():
+        translation_obj[key] = ""
+    for key in lang_strings.keys():
+        if (key in translation_obj):
+            del translation_obj[key]
+        else:
+            not_used.append(key)
+    return {
+        "not_used": not_used,
+        "not_translated": list(translation_obj),
+    }


### PR DESCRIPTION
I working for check translations... actully export is (too much nontraslated strings :-/) :

```json
{
  "not_used": [
    "{0} {0} {0} Contributors, please add your names/usernames separated by comas (for credit purposes)",
    "Add",
    "Available updates",
    "Enable Scoop",
    "Run as administrator",
    "Uninstall selected package",
    "WingetUI version {0}"
  ],
  "not_translated": [
    "{0} aborted",
    "{0} packages were found",
    "{0} package was found",
    "Cache was reset successfully!",
    "Do you really want to uninstall {0} packages?",
    "Instance {0} responded, quitting...",
    "It looks like you ran WingetUI as administrator, which is not recommended. You can still use the program, but we highly recommend not running WingetUI with administrator privileges. Click on \"{showDetails}\" to see why.",
    "The checksum of the installer does not coincide with the expected value, and the authenticity of the installer can't be verified. If you trust the publisher, {0} the package again skipping the hash check.",
    "The installer has an invalid checksum",
    "We could not {action} {package}. Please try again later. Click on \"{showDetails}\" to get the logs from the uninstaller.",
    "We could not load detailed information about this package, because it was not found in any of your package sources"
  ]
}
```

@marticliment 