### PR TITLE
Fixed winget name/version parsing for installed list

### DIFF
--- a/wingetui/wingetHelpers.py
+++ b/wingetui/wingetHelpers.py
@@ -206,8 +206,8 @@ def searchForInstalledPackage(signal: Signal, finishSignal: Signal) -> None:
             while "  " in verElement:
                 verElement = verElement.replace("  ", " ")
             iOffset = 0
-            id = verElement.split(" ")[iOffset+0]
-            ver = verElement.split(" ")[iOffset+1]
+            id = " ".join(verElement.split(" ")[iOffset:-1])
+            ver = verElement.split(" ")[-1]
             if len(id)==1:
                 iOffset + 1
                 id = verElement.split(" ")[iOffset+0]


### PR DESCRIPTION
Previously there was a wrong parsing of packages that were installed locally (not from managers), when package name has more than one word. 

Before (take a look at Adobe Flash, Android Studio etc.):
![image](https://user-images.githubusercontent.com/2964311/232207428-54b9e863-08fd-422d-9e0a-26b1f2e12fc4.png)

After:
![image](https://user-images.githubusercontent.com/2964311/232207485-65d7198a-0086-4e43-85b9-5224054be64f.png)

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**

-----
