### PR TITLE
Fixed WinGet reset script for user profiles with spaces

### DIFF
--- a/wingetui/resources/reset_winget_sources.cmd
+++ b/wingetui/resources/reset_winget_sources.cmd
@@ -1,6 +1,6 @@
 @echo off
-SET wingetpath=%~dp0..\winget-cli\winget.exe
-SET sudopath=%~dp0..\sudo\gsudo.exe
+SET wingetpath="%~dp0..\winget-cli\winget.exe"
+SET sudopath="%~dp0..\sudo\gsudo.exe"
 echo This script will reset winget sources.
 echo You might be asked for administrator rights up to three times during this process.
 echo|set/p="Press <ENTER> to continue or CLOSE THIS WINDOW to abort this process"&runas/u: "">NUL


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**

-----

<!-- optionally, explain here about the committed code -->

`reset_winget_sources.cmd` failed to quote paths, causing it to break if WingetUI is installed at a path containing spaces. This PR adds the missing quotes.

-----
<!-- insert below the issue number (if applicable) -->

Fixes #679