### PR TITLE
Code Update apply_versions.py

### DIFF
--- a/scripts/apply_versions.py
+++ b/scripts/apply_versions.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-os.chdir(os.path.dirname(__file__) + "/..") # move to root project
+os.chdir(os.path.join(os.path.dirname(__file__), "..")) # move to root project
 
 try:
 
@@ -39,4 +39,4 @@ try:
     })
     print("done!")
 except Exception as e:
-    print(e)
+    print(f"Error: {str(e)}")

--- a/scripts/apply_versions.py
+++ b/scripts/apply_versions.py
@@ -38,5 +38,7 @@ try:
         "      StringStruct(u'ProductVersion'": f", u'{versionName}'),\n",
     })
     print("done!")
+except FileNotFoundError as e:
+    print(f"Error: {e.strerror}: {e.filename}")
 except Exception as e:
     print(f"Error: {str(e)}")


### PR DESCRIPTION
os.path.join to join file paths, which is a more robust and platform-independent way to join paths than concatenating strings.

The updated error message is more robust. The original error message did not convert the exception object to a string, so if the exception object did not have a __str__ method defined (which is unlikely but possible), the code would have crashed with a TypeError. By calling str(e), we ensure that we always have a string representation of the error, even if the exception object is not a standard Python exception.

Added checking if file is missing.


- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**

