### PR TITLE
Add manager capabilities

### DIFF
--- a/wingetui/PackageManagers/PackageClasses.py
+++ b/wingetui/PackageManagers/PackageClasses.py
@@ -122,6 +122,15 @@ class InstallationOptions():
         str += f"RemoveDataOnUninstall={self.RemoveDataOnUninstall}>"
         return str
 
+class PackageManagerCapabilities():
+    CanRunAsAdmin: bool = False
+    CanSkipIntegrityChecks: bool = False
+    CanRunInteractively: bool = False
+    CanRemoveDataOnUninstall: bool = False
+    SupportsCustomVersions: bool = False
+    SupportsCustomArchitectures: bool = False
+    SupportsCustomScopes: bool = False
+
 class InstallationWidgetType(QWidget):
     finishInstallation: Signal
     addInfoLine: Signal
@@ -132,6 +141,7 @@ class InstallationWidgetType(QWidget):
     
 class PackageManagerModule():
     NAME: str
+    Capabilities: PackageManagerCapabilities
     def __init__(self):
         pass
     

--- a/wingetui/PackageManagers/choco.py
+++ b/wingetui/PackageManagers/choco.py
@@ -24,6 +24,15 @@ class ChocoPackageManager(SamplePackageManager):
     BLACKLISTED_PACKAGE_IDS =  ["Did", "Features?", "Validation", "-", "being", "It", "Error", "L'accs", "Maximum", "This", "Output is package name ", "operable"]
     BLACKLISTED_PACKAGE_VERSIONS =  ["Did", "Features?", "Validation", "-", "being", "It", "Error", "L'accs", "Maximum", "This", "packages", "current version", "installed version", "is", "program", "validations"]
 
+    Capabilities = PackageManagerCapabilities()
+    Capabilities.CanRunAsAdmin = True
+    Capabilities.CanSkipIntegrityChecks = True
+    Capabilities.CanRunInteractively = True
+    Capabilities.CanRemoveDataOnUninstall = False
+    Capabilities.SupportsCustomVersions = True
+    Capabilities.SupportsCustomArchitectures = True
+    Capabilities.SupportsCustomScopes = False
+    
     if not os.path.exists(CACHE_FILE_PATH):
         os.makedirs(CACHE_FILE_PATH)
         

--- a/wingetui/PackageManagers/npm.py
+++ b/wingetui/PackageManagers/npm.py
@@ -19,7 +19,16 @@ class NPMPackageManager(DynamicLoadPackageManager):
     BLACKLISTED_PACKAGE_NAMES = []
     BLACKLISTED_PACKAGE_IDS = []
     BLACKLISTED_PACKAGE_VERSIONS = []
-
+    
+    Capabilities = PackageManagerCapabilities()
+    Capabilities.CanRunAsAdmin = True
+    Capabilities.CanSkipIntegrityChecks = False
+    Capabilities.CanRunInteractively = False
+    Capabilities.CanRemoveDataOnUninstall = False
+    Capabilities.SupportsCustomVersions = False # TODO: add version listing
+    Capabilities.SupportsCustomArchitectures = False
+    Capabilities.SupportsCustomScopes = True
+    
     icon = None
 
     if not os.path.exists(CACHE_FILE_PATH):

--- a/wingetui/PackageManagers/npm.py
+++ b/wingetui/PackageManagers/npm.py
@@ -169,7 +169,7 @@ class NPMPackageManager(DynamicLoadPackageManager):
                 elif lineNo == 3:
                     details.Description = line.strip()
                 elif line == 4:
-                    details.HomepageURL = line.strip()
+                    details.HomepageURL = line.strip() # TODO: Fix homepage not showing
                 elif line.startswith(".tarball"):
                     details.InstallerURL = line.replace(".tarball: ", "").strip()
                     try:

--- a/wingetui/PackageManagers/pip.py
+++ b/wingetui/PackageManagers/pip.py
@@ -20,6 +20,15 @@ class PipPackageManager(DynamicLoadPackageManager):
     BLACKLISTED_PACKAGE_IDS = ["WARNING:", "[notice]", "Package"]
     BLACKLISTED_PACKAGE_VERSIONS = ["Ignoring", "invalie"]
 
+    Capabilities = PackageManagerCapabilities()
+    Capabilities.CanRunAsAdmin = True
+    Capabilities.CanSkipIntegrityChecks = False
+    Capabilities.CanRunInteractively = False
+    Capabilities.CanRemoveDataOnUninstall = False
+    Capabilities.SupportsCustomVersions = False # TODO: implement version listing
+    Capabilities.SupportsCustomArchitectures = False
+    Capabilities.SupportsCustomScopes = False
+    
     icon = None
 
     if not os.path.exists(CACHE_FILE_PATH):

--- a/wingetui/PackageManagers/pip.py
+++ b/wingetui/PackageManagers/pip.py
@@ -27,7 +27,7 @@ class PipPackageManager(DynamicLoadPackageManager):
     Capabilities.CanRemoveDataOnUninstall = False
     Capabilities.SupportsCustomVersions = False # TODO: implement version listing
     Capabilities.SupportsCustomArchitectures = False
-    Capabilities.SupportsCustomScopes = False
+    Capabilities.SupportsCustomScopes = False # TODO: implement --user custom scope
     
     icon = None
 

--- a/wingetui/PackageManagers/sampleHelper.py
+++ b/wingetui/PackageManagers/sampleHelper.py
@@ -15,8 +15,15 @@ class SamplePackageManager(PackageManagerModule):
     BLACKLISTED_PACKAGE_NAMES = []
     BLACKLISTED_PACKAGE_IDS = []
     BLACKLISTED_PACKAGE_VERSIONS = []
-
-    self = sys.modules[__name__]
+    
+    Capabilities = PackageManagerCapabilities()
+    Capabilities.CanRunAsAdmin = True
+    Capabilities.CanSkipIntegrityChecks = True
+    Capabilities.CanRunInteractively = False
+    Capabilities.CanRemoveDataOnUninstall = False
+    Capabilities.SupportsCustomVersions = True
+    Capabilities.SupportsCustomArchitectures = False
+    Capabilities.SupportsCustomScopes = False
 
     if not os.path.exists(CAHCE_FILE_PATH):
         os.makedirs(CAHCE_FILE_PATH)

--- a/wingetui/PackageManagers/scoop.py
+++ b/wingetui/PackageManagers/scoop.py
@@ -19,6 +19,15 @@ class ScoopPackageManager(SamplePackageManager):
     BLACKLISTED_PACKAGE_NAMES = []
     BLACKLISTED_PACKAGE_IDS = []
     BLACKLISTED_PACKAGE_VERSIONS = []
+    
+    Capabilities = PackageManagerCapabilities()
+    Capabilities.CanRunAsAdmin = True
+    Capabilities.CanSkipIntegrityChecks = True
+    Capabilities.CanRunInteractively = False
+    Capabilities.CanRemoveDataOnUninstall = True
+    Capabilities.SupportsCustomVersions = False
+    Capabilities.SupportsCustomArchitectures = True
+    Capabilities.SupportsCustomScopes = True
 
     icon = None
 

--- a/wingetui/PackageManagers/winget.py
+++ b/wingetui/PackageManagers/winget.py
@@ -19,7 +19,15 @@ class WingetPackageManager(SamplePackageManager):
     BLACKLISTED_PACKAGE_NAMES = [""]
     BLACKLISTED_PACKAGE_IDS = [""]
     BLACKLISTED_PACKAGE_VERSIONS = []
-
+    
+    Capabilities = PackageManagerCapabilities()
+    Capabilities.CanRunAsAdmin = True
+    Capabilities.CanSkipIntegrityChecks = True
+    Capabilities.CanRunInteractively = True
+    Capabilities.CanRemoveDataOnUninstall = False
+    Capabilities.SupportsCustomVersions = True
+    Capabilities.SupportsCustomArchitectures = True
+    Capabilities.SupportsCustomScopes = True
 
     wingetIcon = None
     localIcon = None

--- a/wingetui/storeEngine.py
+++ b/wingetui/storeEngine.py
@@ -118,24 +118,28 @@ class PackageInstallerWidget(QWidget):
         self.leftSlow.setStartValue(0)
         self.leftSlow.setEndValue(1000)
         self.leftSlow.setDuration(700)
+        self.leftSlow.valueChanged.connect(self.update)
         self.leftSlow.finished.connect(lambda: (self.rightSlow.start(), self.changeBarOrientation.emit()))
         
         self.rightSlow = QPropertyAnimation(self.progressbar, b"value")
         self.rightSlow.setStartValue(1000)
         self.rightSlow.setEndValue(0)
         self.rightSlow.setDuration(700)
+        self.rightSlow.valueChanged.connect(self.update)
         self.rightSlow.finished.connect(lambda: (self.leftFast.start(), self.changeBarOrientation.emit()))
         
         self.leftFast = QPropertyAnimation(self.progressbar, b"value")
         self.leftFast.setStartValue(0)
         self.leftFast.setEndValue(1000)
         self.leftFast.setDuration(300)
+        self.leftFast.valueChanged.connect(self.update)
         self.leftFast.finished.connect(lambda: (self.rightFast.start(), self.changeBarOrientation.emit()))
 
         self.rightFast = QPropertyAnimation(self.progressbar, b"value")
         self.rightFast.setStartValue(1000)
         self.rightFast.setEndValue(0)
         self.rightFast.setDuration(300)
+        self.rightFast.valueChanged.connect(self.update)
         self.rightFast.finished.connect(lambda: (self.leftSlow.start(), self.changeBarOrientation.emit()))
 
         self.waitThread = KillableThread(target=self.startInstallation, daemon=True)

--- a/wingetui/uiSections.py
+++ b/wingetui/uiSections.py
@@ -2326,7 +2326,18 @@ class PackageInfoPopupWindow(QWidget):
             for l in self.imagesCarrousel:
                 l.setPixmap(p, index=0)
             Thread(target=self.loadPackageScreenshots, args=(package,)).start()
-
+            
+        Capabilities =  package.PackageManager.Capabilities
+        self.adminCheckbox.setEnabled(Capabilities.CanRunAsAdmin)
+        self.hashCheckBox.setEnabled(Capabilities.CanSkipIntegrityChecks)
+        self.interactiveCheckbox.setEnabled(Capabilities.CanRunInteractively)
+        self.versionCombo.setEnabled(Capabilities.SupportsCustomVersions)
+        self.versionLabel.setEnabled(Capabilities.SupportsCustomVersions)
+        self.architectureCombo.setEnabled(Capabilities.SupportsCustomArchitectures)
+        self.architectureLabel.setEnabled(Capabilities.SupportsCustomArchitectures)
+        self.scopeCombo.setEnabled(Capabilities.SupportsCustomScopes)
+        self.scopeLabel.setEnabled(Capabilities.SupportsCustomScopes)
+        
         self.callInMain.emit(lambda: resetLayoutWidget())
         self.callInMain.emit(lambda: self.appIcon.setPixmap(QIcon(getMedia("install")).pixmap(64, 64)))
         Thread(target=self.loadPackageIcon, args=(package,)).start()
@@ -2349,10 +2360,6 @@ class PackageInfoPopupWindow(QWidget):
         self.loadingProgressBar.hide()
         self.installButton.setEnabled(True)
         self.adminCheckbox.setEnabled(True)
-        self.hashCheckBox.setEnabled(not self.isAnUninstall)
-        self.versionCombo.setEnabled(not self.isAnUninstall and not self.isAnUpdate)
-        self.architectureCombo.setEnabled(not self.isAnUninstall)
-        self.scopeCombo.setEnabled(not self.isAnUninstall)
         if self.isAnUpdate:
             self.installButton.setText(_("Update"))
         elif self.isAnUninstall:
@@ -2401,6 +2408,17 @@ class PackageInfoPopupWindow(QWidget):
             label.setStyleSheet(f"padding: 5px;padding-bottom: 2px;padding-top: 2px;background-color: {blueColor if isDark() else f'rgb({getColors()[0]})'}; color: black; border-radius: 10px;")
             label.setFixedHeight(20)
             self.tagsWidget.layout().addWidget(label)
+            
+        Capabilities =  package.PackageManager.Capabilities
+        self.adminCheckbox.setEnabled(Capabilities.CanRunAsAdmin)
+        self.hashCheckBox.setEnabled(Capabilities.CanSkipIntegrityChecks)
+        self.interactiveCheckbox.setEnabled(Capabilities.CanRunInteractively)
+        self.versionCombo.setEnabled(Capabilities.SupportsCustomVersions)
+        self.versionLabel.setEnabled(Capabilities.SupportsCustomVersions)
+        self.architectureCombo.setEnabled(Capabilities.SupportsCustomArchitectures)
+        self.architectureLabel.setEnabled(Capabilities.SupportsCustomArchitectures)
+        self.scopeCombo.setEnabled(Capabilities.SupportsCustomScopes)
+        self.scopeLabel.setEnabled(Capabilities.SupportsCustomScopes)
 
         self.loadPackageCommandLine()
 

--- a/wingetui/uiSections.py
+++ b/wingetui/uiSections.py
@@ -101,10 +101,15 @@ class DiscoverSoftwareSection(SoftwareSection):
         if self.packageList.currentItem().isHidden():
             return
         ApplyMenuBlur(self.contextMenu.winId().__int__(), self.contextMenu)
-        if self.ItemPackageReference[self.packageList.currentItem()].PackageManager != Scoop:
-            self.InteractiveAction.setVisible(True)
-        else:
-            self.InteractiveAction.setVisible(False)
+        
+        try:
+            Capabilities: PackageManagerCapabilities =  self.ItemPackageReference[self.packageList.currentItem()].PackageManager.Capabilities
+            self.AdminAction.setVisible(Capabilities.CanRunAsAdmin)
+            self.SkipHashAction.setVisible(Capabilities.CanSkipIntegrityChecks)
+            self.InteractiveAction.setVisible(Capabilities.CanRunInteractively)
+        except Exception as e:
+            report(e)
+        
         pos.setY(pos.y()+35)
         self.contextMenu.exec(self.packageList.mapToGlobal(pos))
         
@@ -431,10 +436,15 @@ class UpdateSoftwareSection(SoftwareSection):
             return
         if self.packageList.currentItem().isHidden():
             return
-        if self.ItemPackageReference[self.packageList.currentItem()].PackageManager != Scoop:
-            self.InteractiveAction.setVisible(True)
-        else:
-            self.InteractiveAction.setVisible(False)
+        
+        try:
+            Capabilities: PackageManagerCapabilities =  self.ItemPackageReference[self.packageList.currentItem()].PackageManager.Capabilities
+            self.AdminAction.setVisible(Capabilities.CanRunAsAdmin)
+            self.SkipHashAction.setVisible(Capabilities.CanSkipIntegrityChecks)
+            self.InteractiveAction.setVisible(Capabilities.CanRunInteractively)
+        except Exception as e:
+            report(e)
+            
         pos.setY(pos.y()+35)
         ApplyMenuBlur(self.contextMenu.winId().__int__(), self.contextMenu)
 
@@ -881,9 +891,14 @@ class UninstallSoftwareSection(SoftwareSection):
             return
         ApplyMenuBlur(self.contextMenu.winId().__int__(), self.contextMenu)
                     
-        self.RemoveDataAction.setVisible(self.ItemPackageReference[self.packageList.currentItem()].PackageManager == Scoop)
-        self.InteractiveAction.setVisible(self.ItemPackageReference[self.packageList.currentItem()].PackageManager != Scoop)
-        
+        try:
+            Capabilities: PackageManagerCapabilities =  self.ItemPackageReference[self.packageList.currentItem()].PackageManager.Capabilities
+            self.AdminAction.setVisible(Capabilities.CanRunAsAdmin)
+            self.RemoveDataAction.setVisible(Capabilities.CanRemoveDataOnUninstall)
+            self.InteractiveAction.setVisible(Capabilities.CanRunInteractively)
+        except Exception as e:
+            report(e)
+                    
         if self.ItemPackageReference[self.packageList.currentItem()].Source not in ((_("Local PC"), "Microsoft Store", "Steam", "GOG", "Ubisoft Connect", _("Android Subsystem"))):
             self.IgnoreUpdatesAction.setVisible(True)
             self.ShareAction.setVisible(True)


### PR DESCRIPTION
Package managers will declare which capabilities they support, in order for the interface to enable or disable certain elements based on this.