### PR TITLE
fix unable to build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PySide6>=6.5.1.1
 win32mica>=1.9
-PyInstaller==5.11.0
+PyInstaller>=5.11.0
 pywin32
 Flask
 flask-cors


### PR DESCRIPTION
Downgrading PyInstaller creates error
<img width="258" alt="Screenshot 2023-06-16 123730" src="https://github.com/marticliment/WingetUI/assets/73800734/37d438cb-4497-4e27-a164-449c30099e44">

<!-- Provide a general summary of your changes in the title above -->

- [ ] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [ ] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [ ] **Have you tested that the committed code can be executed without errors?**

-----

<!-- optionally, explain here about the committed code -->

-----
<!-- insert below the issue number (if applicable) -->

Closes #XXXX
<!-- or -->
Relates to #XXXX
