### PR TITLE
[PR] Accept package agreements when updating

### DIFF
--- a/wingetui/PackageManagers/winget.py
+++ b/wingetui/PackageManagers/winget.py
@@ -626,7 +626,7 @@ class WingetPackageManager(DynamicPackageManager):
     def startUpdate(self, package: Package, options: InstallationOptions, widget: InstallationWidgetType) -> subprocess.Popen:
         if "…" in package.Id:
             package.Id = self.getFullPackageId(package.Id)
-        Command = [self.EXECUTABLE, "upgrade"] + (["--id", package.Id, "--exact"] if not "…" in package.Id else ["--name", '"'+package.Name+'"']) + ["--include-unknown"] + self.getParameters(options)
+        Command = [self.EXECUTABLE, "upgrade"] + (["--id", package.Id, "--exact"] if not "…" in package.Id else ["--name", '"'+package.Name+'"']) + ["--include-unknown"] + self.getParameters(options) + ["--accept-package-agreements"]
         if options.RunAsAdministrator:
             Command = [GSUDO_EXECUTABLE] + Command
         print(f"🔵 Starting {package} update with Command", Command)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [ ] **Have you tested that the committed code can be executed without errors?**

-----

<!-- optionally, explain here about the committed code -->
When trying to update the `RedisInsight` package, the upgrade would fail with:
> Package agreements were not agreed to. Operation cancelled.

I was able to upgrade using winget directly by passing the `--accept-package-agreements` argument, which is already set by WinGetUI for package installations but not updates.

Error log:
```
🟢 Waiting for install permission... title=RedisInsight-v2 2.28.0, id=XP8K1GHCB0F1R2, installId=1690530572.454407
🔵 Given package: <Package: RedisInsight-v2 2.28.0;XP8K1GHCB0F1R2;2.28.0;Winget: msstore;<PackageManagers.winget.WingetPackageManager object at 0x000001AC28D574D0>;<genericCustomWidgets.TreeWidgetItemWithQAction object at 0x000001AC455157C0>>
🔵 Installation options: <InstallationOptions: SkipHashCheck=False;InteractiveInstallation=False;RunAsAdministrator=False;Version=;Architecture=;InstallationScope=;CustomParameters=[];RemoveDataOnUninstall=False>
[<storeEngine.PackageUpdaterWidget(0x1ac4905ba00, name="package") at 0x000001AC428F5F40>]
🔵 Found icon:  
🟡 Icon url empty
🟡 Icon  not found in json
🟡 Icon for XP8K1GHCB0F1R2 does not exist
🔵 Current program set to 1690530572.454407
🟢 Have permission to install, starting installation threads...
🔵 Starting <Package: RedisInsight-v2 2.28.0;XP8K1GHCB0F1R2;2.28.0;Winget: msstore;<PackageManagers.winget.WingetPackageManager object at 0x000001AC28D574D0>;<genericCustomWidgets.TreeWidgetItemWithQAction object at 0x000001AC455157C0>> update with Command ['C:\\Users\\Vsilvar\\AppData\\Local\\Programs\\WingetUI\\PackageManagers\\winget-cli_x64\\winget.exe', 'upgrade', '--id', 'XP8K1GHCB0F1R2', '--exact', '--include-unknown', '--accept-source-agreements', '--disable-interactivity']
OverflowError
['- \r   \\ \r                                                                                                                        \r\r  █▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  1024 KB / 15.7 MB\r  ███▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  2.00 MB / 15.7 MB\r  █████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  3.00 MB / 15.7 MB\r  ███████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  4.00 MB / 15.7 MB\r  █████████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  5.00 MB / 15.7 MB\r  ███████████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  6.00 MB / 15.7 MB\r  █████████████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  7.00 MB / 15.7 MB\r  ███████████████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒  8.00 MB / 15.7 MB\r  █████████████████▒▒▒▒▒▒▒▒▒▒▒▒▒  9.00 MB / 15.7 MB\r  ███████████████████▒▒▒▒▒▒▒▒▒▒▒  10.0 MB / 15.7 MB\r  ████████████████████▒▒▒▒▒▒▒▒▒▒  11.0 MB / 15.7 MB\r  ██████████████████████▒▒▒▒▒▒▒▒  12.0 MB / 15.7 MB\r  ████████████████████████▒▒▒▒▒▒  13.0 MB / 15.7 MB\r  ██████████████████████████▒▒▒▒  14.0 MB / 15.7 MB\r  ████████████████████████████▒▒  15.0 MB / 15.7 MB\r  ██████████████████████████████  15.7 MB / 15.7 MB\r                                                                                                                        \r\r   - \r   \\ \r                                                                                                                        \rFound RedisInsight [XP8K1GHCB0F1R2] Version 2.30.0', 'This application is licensed to you by its owner.', 'Microsoft is not responsible for, nor does it grant any licenses to, third-party packages.', 'Agreements for RedisInsight [XP8K1GHCB0F1R2] Version 2.30.0', 'Version: 2.30.0', 'Publisher: Redis', 'Publisher Url: https://redis.com/redis-enterprise/redis-insight/', 'Publisher Support Url: https://github.com/RedisInsight/RedisInsight/issues', 'Description:', 'RedisInsight is an ideal tool for developers who build with any Redis deployments – including Redis Open Source, Redis Stack, Redis Enterprise Software, Redis Enterprise Cloud, and Amazon ElastiCache – and who want to optimize their development process. RedisInsight lets you visually browse and interact with data, take advantage of the advanced command line interface and diagnostic tools, and so much more.', 'RedisInsight lets you:', '* visually browse and interact with data', '* quickly run Redis commands using our advanced command line interface', '* visualize your data', '* troubleshoot and debug', '* use diagnostic tools to decrease memory usage and optimize your Redis or Redis Stack database', '* and so much more!', 'License: Server Side Public License, V1', 'https://github.com/RedisInsight/RedisInsight/blob/main/LICENSE', 'Privacy Url: https://redis.com/legal/redis-insight-license-terms/', 'Copyright: Redis Inc.', 'Tags:', 'redis', 'redis UI', 'redis GUI', 'GUI redis', 'UI redis', 'RedisInsight', 'redis CLI', 'Agreements:', 'Category: Developer tools', 'Pricing: Freemium', 'Free Trial: No', 'Terms of Transaction: https://aka.ms/microsoft-store-terms-of-transaction', 'Seizure Warning: https://aka.ms/microsoft-store-seizure-warning', 'Store License Terms: https://aka.ms/microsoft-store-license', 'Package agreements were not agreed to. Operation cancelled.', '']
```

