### PR TITLE
Change Winget Releaser job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   publish:
-    runs-on: windows-latest # action can only be run on windows
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**

-----

<!-- optionally, explain here about the committed code -->

Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.

-----
<!-- insert below the issue number (if applicable) -->

Relates to https://github.com/marticliment/ElevenClock/pull/1239
