### PR TITLE
Account for cases where the user has a PowerShell profile

### DIFF
--- a/scripts/generate_excel_from_json.py
+++ b/scripts/generate_excel_from_json.py
@@ -72,7 +72,7 @@ def getScoopPackages():
     pkgs = []
     print("🟢 Starting scoop search...")
     ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
-    p = subprocess.Popen(' '.join(["powershell", "-Command", "scoop", "search"]), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, cwd=os.getcwd(), env=os.environ, shell=True)
+    p = subprocess.Popen(' '.join(["powershell", "-NoProfile", "-Command", "scoop", "search"]), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE, cwd=os.getcwd(), env=os.environ, shell=True)
     output = []
     counter = 0
     while p.poll() is None:

--- a/wingetui/PackageManagers/choco.py
+++ b/wingetui/PackageManagers/choco.py
@@ -322,8 +322,8 @@ class ChocoPackageManager(DynamicPackageManager):
 
         if getSettings("ShownWelcomeWizard") and not getSettings("UseSystemChocolatey") and not getSettings("ChocolateyAddedToPath") and not os.path.isfile(r"C:\ProgramData\Chocolatey\bin\choco.exe"):
             # If the user is running bundled chocolatey and chocolatey is not in path, add chocolatey to path
-            subprocess.run("powershell -Command [Environment]::SetEnvironmentVariable(\\\"PATH\\\", \\\"" + self.EXECUTABLE.replace('\\choco.exe', '\\bin') + ";\\\"+[Environment]::GetEnvironmentVariable(\\\"PATH\\\", \\\"User\\\"), \\\"User\\\")", shell=True, check=False)
-            subprocess.run(f"powershell -Command [Environment]::SetEnvironmentVariable(\\\"chocolateyinstall\\\", \\\"{os.path.dirname(self.EXECUTABLE)}\\\", \\\"User\\\")", shell=True, check=False)
+            subprocess.run("powershell -NoProfile -Command [Environment]::SetEnvironmentVariable(\\\"PATH\\\", \\\"" + self.EXECUTABLE.replace('\\choco.exe', '\\bin') + ";\\\"+[Environment]::GetEnvironmentVariable(\\\"PATH\\\", \\\"User\\\"), \\\"User\\\")", shell=True, check=False)
+            subprocess.run(f"powershell -NoProfile -Command [Environment]::SetEnvironmentVariable(\\\"chocolateyinstall\\\", \\\"{os.path.dirname(self.EXECUTABLE)}\\\", \\\"User\\\")", shell=True, check=False)
             print("🔵 Adding chocolatey to path...")
             setSettings("ChocolateyAddedToPath", True)
 

--- a/wingetui/PackageManagers/scoop.py
+++ b/wingetui/PackageManagers/scoop.py
@@ -29,7 +29,7 @@ class ScoopPackageManager(DynamicPackageManager):
 
     ansi_escape = re.compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
 
-    EXECUTABLE = "powershell -ExecutionPolicy ByPass -Command scoop"
+    EXECUTABLE = "powershell -NoProfile -ExecutionPolicy ByPass -Command scoop"
 
     NAME = "Scoop"
     CACHE_FILE = os.path.join(os.path.expanduser("~"), f".wingetui/cacheddata/{NAME}CachedPackages")

--- a/wingetui/__init__.py
+++ b/wingetui/__init__.py
@@ -310,7 +310,7 @@ try:
         def getAUMID(self):
             print("🔵 Loading WingetUI AUMID...")
             try:
-                output = str(subprocess.check_output(["powershell", "-Command", "Get-StartApps"], shell=True), encoding='utf-8', errors='ignore')
+                output = str(subprocess.check_output(["powershell", "-NoProfile", "-Command", "Get-StartApps"], shell=True), encoding='utf-8', errors='ignore')
                 for line in output.split("\n"):
                     if list(filter(None, line.split(" ")))[0] == "WingetUI":
                         globals.AUMID = list(filter(None, line.split(" ")))[1]


### PR DESCRIPTION
- [ x ] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [ x ] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [ x ] **Have you tested that the committed code can be executed without errors?**

-----

- Add a `-NoProfile` to every location PowerShell is executed
  - Fixes a bug where the listed Scoop updates would include the output of the PowerShell profile
  - Also makes it faster as it doesn't have to execute the PowerShell profile before searching for updates
  - Added it to the other locations as well, as they are likely either bugged or slower than they have to be

Before:
![image](https://github.com/marticliment/WingetUI/assets/60557606/ad72564e-c62b-4870-951b-31a27c5b138e)

After:
![image](https://github.com/marticliment/WingetUI/assets/60557606/aaf89ad6-9e74-4840-83e8-6cd9f8ad9245)

-----
