### PR TITLE
readme: Make install through Winget command more specific

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ With this app, you'll be able to easily download, install, update and uninstall 
 
 **Install WingetUI through Winget:**    
 ```cmd
-winget install wingetui
+winget install SomePythonThings.WingetUIStore
 ```
 
 **Install WingetUI through Scoop:**


### PR DESCRIPTION
readme: Make install through Winget command more specific

When using just "winget install wingetui", Winget complains about
multiple packages carrying similar names and asks the user to be more
specific. Therefore, use the actual package ID in the installation
command.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

<!-- Provide a general summary of your changes in the title above -->

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**

The screenshot is in Korean, but it basically shows that Winget finds two packages with "wingetui" in their name and asks you to be more specific.

![image](https://github.com/marticliment/WingetUI/assets/5626656/78a1c58c-c69a-4239-bf85-c4989cb49ca0)
