### PR TITLE
Fix window rising to top after accent color change

### DIFF
--- a/wingetui/Interface/MainWindow.py
+++ b/wingetui/Interface/MainWindow.py
@@ -281,7 +281,7 @@ class RootWindow(QMainWindow):
                                       ctypes.sizeof(value))
 
             user32.SetWindowPos(int(self.winId()),
-                                0, 0, 0, 0, 0,
+                                -2, 0, 0, 0, 0,
                                 0x0020 | 0x0002 | 0x0004 | 0x0001)
 
     def nativeEvent(self, eventType, message):


### PR DESCRIPTION
Fix window rising to top on chaging theme back.

<!-- Provide a general summary of your changes in the title above -->

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**

-----

This change fixes the theme change bug in which the raises itself while fixing its theme when the accent color changes.

I would also try to look into the main theme change issue #1407 in sometime as it requires quiet some trial and error + testing and I am currently not having much time for it. This was a small fix to be made.

Please confirm if it works on Windows 11 (I have tested on Windows 10).
Thanks

-----
<!-- insert below the issue number (if applicable) -->

Closes #1707 
