### PR TITLE
#1873 Fix inverted condition for interactive installation of chocolatey packages

### DIFF
--- a/src/wingetui/PackageEngine/Managers/Chocolatey.cs
+++ b/src/wingetui/PackageEngine/Managers/Chocolatey.cs
@@ -221,7 +221,7 @@ namespace ModernWindow.PackageEngine.Managers
             if (options.CustomParameters != null)
                 parameters.AddRange(options.CustomParameters);
 
-            if (!options.InteractiveInstallation)
+            if (options.InteractiveInstallation)
                 parameters.Add("--notsilent");
 
             return parameters.ToArray();


### PR DESCRIPTION
As I already had a look at the code via browser I pulled the repo and tested the change. Uninverting the interactive install condition is all that is necessary.

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**


```
▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
Starting package update operation for package id=k-litecodecpackbasicwith Manager name=Chocolatey
Given installation options are <InstallationOptions: SkipHashCheck=False;InteractiveInstallation=True;RunAsAdministrator=False;Version=;Architecture=;InstallationScope=;InstallationScope=;CustomParameters=;RemoveDataOnUninstall=False>
Process Executable     : C:\Projects\WingetUI\src\wingetui\bin\x64\Debug\net8.0-windows10.0.19041.0\Assets\Utilities\gsudo.exe
Process Call Arguments : "C:\ProgramData\chocolatey\bin\choco.exe" upgrade k-litecodecpackbasic -y --notsilent --no-progress
Working Directory      : C:\Users\David
Process Start Time     : 08.03.2024 17:34:18
    ║ Chocolatey v2.2.2
    ║ 3 validations performed. 2 success(es), 1 warning(s), and 0 error(s).
    ║ Validation Warnings:
    ║  - System Cache directory is not locked down to administrators.
    ║    Remove the directory 'C:\ProgramData\ChocolateyHttpCache' to have
    ║    Chocolatey CLI create it with the proper permissions.
    ║ Upgrading the following packages:
    ║ k-litecodecpackbasic
    ║ By upgrading, you accept licenses for the packages.
    ║ You have k-litecodecpackbasic v18.1.0 installed. Version 18.1.5 is available based on your source(s).
    ║ k-litecodecpackbasic v18.1.5 [Approved]
    ║ k-litecodecpackbasic package files upgrade completed. Performing other installation steps.
    ║ Downloading k-litecodecpackbasic 
    ║   from 'https://files3.codecguide.com/K-Lite_Codec_Pack_1815_Basic.exe'
    ║ Download of K-Lite_Codec_Pack_1815_Basic.exe (19.45 MB) completed.
    ║ Hashes match.
    ║ Installing k-litecodecpackbasic...
    ║ Overriding package arguments with '' (replacing '/VERYSILENT /NORESTART')
    ║ k-litecodecpackbasic has been installed.
    ║   k-litecodecpackbasic can be automatically uninstalled.
    ║  The upgrade of k-litecodecpackbasic was successful.
    ║   Software installed to 'C:\Program Files (x86)\K-Lite Codec Pack\'
    ║ Chocolatey upgraded 1/1 packages. 
    ║  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
Process Exit Code      : 0
Process End Time       : 08.03.2024 17:34:44
▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
Starting package update operation for package id=powertoyswith Manager name=Chocolatey
Given installation options are <InstallationOptions: SkipHashCheck=False;InteractiveInstallation=False;RunAsAdministrator=False;Version=;Architecture=;InstallationScope=;InstallationScope=;CustomParameters=;RemoveDataOnUninstall=False>
Process Executable     : C:\Projects\WingetUI\src\wingetui\bin\x64\Debug\net8.0-windows10.0.19041.0\Assets\Utilities\gsudo.exe
Process Call Arguments : "C:\ProgramData\chocolatey\bin\choco.exe" upgrade powertoys -y --no-progress
Working Directory      : C:\Users\David
Process Start Time     : 08.03.2024 17:32:13
    ║ Chocolatey v2.2.2
    ║ 3 validations performed. 2 success(es), 1 warning(s), and 0 error(s).
    ║ Validation Warnings:
    ║  - System Cache directory is not locked down to administrators.
    ║    Remove the directory 'C:\ProgramData\ChocolateyHttpCache' to have
    ║    Chocolatey CLI create it with the proper permissions.
    ║ Upgrading the following packages:
    ║ powertoys
    ║ By upgrading, you accept licenses for the packages.
    ║ You have powertoys v0.78.0 installed. Version 0.79.0 is available based on your source(s).
    ║ powertoys v0.79.0 [Approved]
    ║ powertoys package files upgrade completed. Performing other installation steps.
    ║ File appears to be downloaded already. Verifying with package checksum to determine if it needs to be redownloaded.
    ║ Hashes match.
    ║ Hashes match.
    ║ Installing powertoys...
    ║ powertoys has been installed.
    ║   powertoys may be able to be automatically uninstalled.
    ║  The upgrade of powertoys was successful.
    ║   Software installed to 'C:\Program Files\PowerToys\'
    ║ Chocolatey upgraded 1/1 packages. 
    ║  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
Process Exit Code      : 0
Process End Time       : 08.03.2024 17:33:02
```


-----

<!-- optionally, explain here about the committed code -->

-----
<!-- insert below the issue number (if applicable) -->

Closes #1873 
