### PR TITLE
SoftwarePage width

### DIFF
--- a/src/wingetui/Interface/SoftwarePages/DiscoverPackages.xaml
+++ b/src/wingetui/Interface/SoftwarePages/DiscoverPackages.xaml
@@ -583,13 +583,13 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="1000000*" MaxWidth="1350"/>
-            <ColumnDefinition Width="*"/>
-        </Grid.ColumnDefinitions>
+            <ColumnDefinition Width="8"/>
+            <ColumnDefinition Width="*" MinWidth="1350"/>
+            <ColumnDefinition Width="8"/>
+    </Grid.ColumnDefinitions>
 
         <!-- HEADER -->
-        <Grid Name="MainHeader" Grid.Row="0" Grid.Column="1" >
+        <Grid Name="MainHeader" Grid.Row="0" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="80"/>
                 <ColumnDefinition Width="*"/>

--- a/src/wingetui/Interface/SoftwarePages/DiscoverPackages.xaml
+++ b/src/wingetui/Interface/SoftwarePages/DiscoverPackages.xaml
@@ -583,9 +583,9 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="8"/>
-            <ColumnDefinition Width="*" MinWidth="1350"/>
-            <ColumnDefinition Width="8"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="1000000*" MaxWidth="2000"/>
+            <ColumnDefinition Width="*"/>
     </Grid.ColumnDefinitions>
 
         <!-- HEADER -->

--- a/src/wingetui/Interface/SoftwarePages/InstalledPackages.xaml
+++ b/src/wingetui/Interface/SoftwarePages/InstalledPackages.xaml
@@ -583,9 +583,9 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="8"/>
-            <ColumnDefinition Width="*" MinWidth="1350"/>
-            <ColumnDefinition Width="8"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="1000000*" MaxWidth="2000"/>
+            <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
         <!-- HEADER -->

--- a/src/wingetui/Interface/SoftwarePages/InstalledPackages.xaml
+++ b/src/wingetui/Interface/SoftwarePages/InstalledPackages.xaml
@@ -583,9 +583,9 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="1000000*" MaxWidth="1350"/>
-            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="8"/>
+            <ColumnDefinition Width="*" MinWidth="1350"/>
+            <ColumnDefinition Width="8"/>
         </Grid.ColumnDefinitions>
 
         <!-- HEADER -->

--- a/src/wingetui/Interface/SoftwarePages/PackageBundle.xaml
+++ b/src/wingetui/Interface/SoftwarePages/PackageBundle.xaml
@@ -584,9 +584,9 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="1000000*" MaxWidth="1350"/>
-            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="8"/>
+            <ColumnDefinition Width="*" MinWidth="1350"/>
+            <ColumnDefinition Width="8"/>
         </Grid.ColumnDefinitions>
 
         <!-- HEADER -->

--- a/src/wingetui/Interface/SoftwarePages/PackageBundle.xaml
+++ b/src/wingetui/Interface/SoftwarePages/PackageBundle.xaml
@@ -584,9 +584,9 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="8"/>
-            <ColumnDefinition Width="*" MinWidth="1350"/>
-            <ColumnDefinition Width="8"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="1000000*" MaxWidth="2000"/>
+            <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
         <!-- HEADER -->

--- a/src/wingetui/Interface/SoftwarePages/SoftwareUpdates.xaml
+++ b/src/wingetui/Interface/SoftwarePages/SoftwareUpdates.xaml
@@ -598,9 +598,9 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="1000000*" MaxWidth="1350"/>
-            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="8"/>
+            <ColumnDefinition Width="*" MinWidth="1350"/>
+            <ColumnDefinition Width="8"/>
         </Grid.ColumnDefinitions>
 
         <!-- HEADER -->

--- a/src/wingetui/Interface/SoftwarePages/SoftwareUpdates.xaml
+++ b/src/wingetui/Interface/SoftwarePages/SoftwareUpdates.xaml
@@ -598,9 +598,9 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="8"/>
-            <ColumnDefinition Width="*" MinWidth="1350"/>
-            <ColumnDefinition Width="8"/>
+            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="1000000*" MaxWidth="2000"/>
+            <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
         <!-- HEADER -->


### PR DESCRIPTION

Changes:
Changed rootgrid column widths on SoftwarePages to make the pages populate more of the available space on wider window sizes.

Notes
Not sure about your intent for the look of these pages are but this should change them to keep the same spacing to the edges of the window unless made thinner than the minimum sizes.

Before:
![image](https://github.com/marticliment/WingetUI/assets/19716996/ff27b7a0-38b6-4d7e-a879-a6916c5e1385)

After:
![image](https://github.com/marticliment/WingetUI/assets/19716996/8e65ea98-7795-47f1-a826-cc71d833e78b)


<!-- Provide a general summary of your changes in the title above -->

- [ ] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [ ] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [ ] **Have you tested that the committed code can be executed without errors?**


### DO NOT publish garbage PRs to farm Crypto AirDrops. Any user suspected of this action will get banned. Submitting broken code wastes the time of the contributors, who have to spend their free time reviewing, fixing and testing code that does not even compile, breaks other features or does not introduce any changes.


-----

<!-- optionally, explain here about the committed code -->

-----
<!-- insert below the issue number (if applicable) -->

Closes #XXXX
<!-- or -->
Relates to #XXXX
