### PR TITLE
Show 'Update' Button in Tray Notification When Only One Update is Available

### DIFF
--- a/src/wingetui/Interface/SoftwarePages/SoftwareUpdates.xaml.cs
+++ b/src/wingetui/Interface/SoftwarePages/SoftwareUpdates.xaml.cs
@@ -360,8 +360,8 @@ namespace ModernWindow.Interface
                             attribution += package.Name + ", ";
                         }
                         attribution = attribution.TrimEnd(' ').TrimEnd(',');
-                        ShowButtons = true;
                     }
+                    ShowButtons = true;
                 }
 
                 if (!Tools.GetSettings("DisableUpdatesNotifications") && !Tools.GetSettings("DisableNotifications"))
@@ -382,7 +382,7 @@ namespace ModernWindow.Interface
                                 .AddArgument("action", "openWingetUIOnUpdatesTab")
                                 .SetBackgroundActivation());
                             toast.AddButton(new ToastButton()
-                                .SetContent(Tools.Translate("Update all"))
+                                .SetContent(Tools.Translate(upgradablePackages.Count == 1 ? "Update" : "Update all"))
                                 .AddArgument("action", "updateAll")
                                 .SetBackgroundActivation());
                         }

--- a/src/wingetui/Interface/SoftwarePages/SoftwareUpdates.xaml.cs
+++ b/src/wingetui/Interface/SoftwarePages/SoftwareUpdates.xaml.cs
@@ -382,7 +382,7 @@ namespace ModernWindow.Interface
                                 .AddArgument("action", "openWingetUIOnUpdatesTab")
                                 .SetBackgroundActivation());
                             toast.AddButton(new ToastButton()
-                                .SetContent(Tools.Translate(upgradablePackages.Count == 1 ? "Update" : "Update all"))
+                                .SetContent(upgradablePackages.Count == 1? Tools.Translate("Update"): Tools.Translate("Update all"))
                                 .AddArgument("action", "updateAll")
                                 .SetBackgroundActivation());
                         }


### PR DESCRIPTION
Currently, if the user is notified about new available updates via a tray notification, they are given the option to `Update All` or `Open WingetUI`. However, if only a single update is available, these buttons are not shown. This PR removes that distinction, allowing the user to request the upgrade of a single package from the notification without opening the app.

In this case, the `Update All` text is changed to `Update` to reflect the fact that only a single package can be updated.

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
