### PR TITLE
Fix #1995: [BUG] Notification tray icon

### DIFF
--- a/src/wingetui/Interface/MainWindow.xaml.cs
+++ b/src/wingetui/Interface/MainWindow.xaml.cs
@@ -219,6 +219,7 @@ namespace ModernWindow
 
             TrayIcon = new TaskbarIcon();
             __content_root.Children.Add(TrayIcon);
+            Closed += (s, e) => TrayIcon.Dispose();
             TrayIcon.ContextMenuMode = H.NotifyIcon.ContextMenuMode.PopupMenu;
 
             XamlUICommand ShowHideCommand = new();


### PR DESCRIPTION
Disposes the `TrayIcon` object when the `MainWindow` is closed so that the icon is removed from the taskbar tray.

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the time of the contributors, who have to spend their free time reviewing, fixing and testing code that does not even compile, breaks other features or does not introduce any useful changes. Thank you for your understanding

-----
<!-- insert below the issue number (if applicable) -->

Resolves #1995 
