### PR TITLE
fix scoop-search autofix error

### DIFF
--- a/src/wingetui/PackageEngine/Managers/Scoop.cs
+++ b/src/wingetui/PackageEngine/Managers/Scoop.cs
@@ -31,7 +31,7 @@ public class Scoop : PackageManagerWithSources
             {
                 StartInfo = new ProcessStartInfo()
                 {
-                    FileName = path,
+                    FileName = Status.ExecutablePath,
                     Arguments = Properties.ExecutableCallArgs + " install main/scoop-search",
                     UseShellExecute = true,
                     CreateNoWindow = true


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding) and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the time of the contributors, who have to spend their free time reviewing, fixing and testing code that does not even compile, breaks other features or does not introduce any useful changes. Thank you for your understanding


-----

Fix automatic repair program not executing correctly when `scoop-search` is not installed
### issue testing
1. `scoop uninstall scoop-search`
2. research in WingetUI

-----
<!-- insert below the issue number (if applicable) -->

