### PR TITLE
Add translation string in the installer ("Install Chocolatey")

### DIFF
--- a/InstallerExtras/CustomMessages.iss
+++ b/InstallerExtras/CustomMessages.iss
@@ -1,4 +1,5 @@
 ﻿[CustomMessages]
+; Armenian, Brazilian Portuguese, Catalan, Corsican, Czech, Danish, Dutch, Finnish, French, German, Hebrew, Icelandic, Italian, Japanese, Korean, Norwegian, Polish, Portuguese, Russian, Slovenian, Spanish, Turkish, Ukrainian
 
 ; English
 InstallType=Installation type
@@ -7,6 +8,7 @@ PortInst=Perform a portable installation
 RegInst=Perform a regular installation
 RegStartMmenuIcon=Create a shortcut on the Start menu
 RegDesktopIcon=Create a shortcut on the Desktop
+ChocoInstall=Install Chocolatey
 
 ; Armenian
 Armenian.InstallType=Տեղադրման տեսակը
@@ -15,6 +17,7 @@ Armenian.PortInst=Կատարել շարժական տեղադրում
 Armenian.RegInst=Կատարել սովորական տեղադրում
 Armenian.RegStartMmenuIcon=Ստեղծեք դյուրանցում Start ընտրացանկում
 Armenian.RegDesktopIcon=Ստեղծեք դյուրանցում աշխատասեղանի վրա
+Armenian.ChocoInstall=Ինստալացնել Chocolatey
 
 ; BrazilianPortuguese
 BrazilianPortuguese.InstallType=Tipo de instalação
@@ -23,6 +26,7 @@ BrazilianPortuguese.PortInst=Realizar uma instalação portátil
 BrazilianPortuguese.RegInst=Realizar uma instalação regular
 BrazilianPortuguese.RegStartMmenuIcon=Criar um atalho no menu Iniciar
 BrazilianPortuguese.RegDesktopIcon=Criar um atalho na área de trabalh
+BrazilianPortuguese.ChocoInstall=Instalar Chocolatey
 
 ; Catalan
 Catalan.InstallType=Tipus d'instal·lació
@@ -31,6 +35,7 @@ Catalan.PortInst=Feu una instal·lació portàtil
 Catalan.RegInst=Feu una instal·lació regular
 Catalan.RegStartMmenuIcon=Creeu una drecera al menú Inici
 Catalan.RegDesktopIcon=Creeu una drecera a l'Escriptori
+Catalan.ChocoInstall=Instal·lar Chocolatey
 
 ; Corsican
 Corsican.InstallType=Tipu d'installazione
@@ -39,6 +44,7 @@ Corsican.PortInst=Eseguite una installazione portable
 Corsican.RegInst=Eseguite una installazione regulare
 Corsican.RegStartMmenuIcon=Create una scorciatoia nant'à u menu Start
 Corsican.RegDesktopIcon=Create una scorciatoia nant'à u Desktop
+Corsican.ChocoInstall=Stallà Chocolatey
 
 ; Czech
 Czech.InstallType=Typ instalace
@@ -47,6 +53,7 @@ Czech.PortInst=Proveďte přenosnou instalaci
 Czech.RegInst=Proveďte běžnou instalaci
 Czech.RegStartMmenuIcon=Vytvořte zástupce v nabídce Start
 Czech.RegDesktopIcon=Vytvořte zástupce na ploše
+Czech.ChocoInstall=Nainstalovat Chocolatey
 
 ; Danish
 Danish.InstallType=Installationstype
@@ -55,6 +62,7 @@ Danish.PortInst=Udfør en bærbar installation
 Danish.RegInst=Udfør en almindelig installation
 Danish.RegStartMmenuIcon=Opret en genvej på Start-menuen
 Danish.RegDesktopIcon=Opret en genvej på skrivebordet
+Danish.ChocoInstall=Installer Chocolatey
 
 ; Dutch
 Dutch.InstallType=Installatietype
@@ -63,6 +71,7 @@ Dutch.PortInst=Voer een draagbare installatie uit
 Dutch.RegInst=Voer een normale installatie uit
 Dutch.RegStartMmenuIcon=Maak een snelkoppeling in het Startmenu
 Dutch.RegDesktopIcon=Maak een snelkoppeling op het bureaublad
+Dutch.ChocoInstall=Installeer Chocolatey
 
 ; Finnish
 Finnish.InstallType=Asennustyyppi
@@ -71,6 +80,7 @@ Finnish.PortInst=Suorita kannettava asennus
 Finnish.RegInst=Suorita tavallinen asennus
 Finnish.RegStartMmenuIcon=Luo pikakuvake Käynnistä-valikkoon
 Finnish.RegDesktopIcon=Luo pikakuvake työpöydälle
+Finnish.ChocoInstall=Asenna Chocolatey
 
 ; French
 French.InstallType=Type d'installation
@@ -79,6 +89,7 @@ French.PortInst=Effectuer une installation portable
 French.RegInst=Effectuer une installation normale
 French.RegStartMmenuIcon=Créer un raccourci dans le menu Démarrer
 French.RegDesktopIcon=Créer un raccourci sur le bureau
+French.ChocoInstall=Installer Chocolatey
 
 ; German
 German.InstallType=Installationstyp
@@ -87,6 +98,7 @@ German.PortInst=Führe eine portable Installation durch
 German.RegInst=Führe eine normale Installation durch
 German.RegStartMmenuIcon=Erstelle eine Verknüpfung im Startmenü
 German.RegDesktopIcon=Erstelle eine Verknüpfung auf dem Desktop
+German.ChocoInstall=Chocolatey installieren
 
 ; Hebrew
 Hebrew.InstallType=סוג התקנה
@@ -95,6 +107,7 @@ Hebrew.PortInst=בצע התקנה ניידת
 Hebrew.RegInst=בצע התקנה רגילה
 Hebrew.RegStartMmenuIcon=צור קיצור דרך בתפריט התחל
 Hebrew.RegDesktopIcon=צור קיצור דרך בשולחן העבודה
+Hebrew.ChocoInstall=להתקין את Chocolatey
 
 ; Icelandic
 Icelandic.InstallType=Uppsetningargerð
@@ -103,6 +116,7 @@ Icelandic.PortInst=Framkvæma færanlega uppsetningu
 Icelandic.RegInst=Framkvæma reglulega uppsetningu
 Icelandic.RegStartMmenuIcon=Búa til flýtileið á Start valmyndinni
 Icelandic.RegDesktopIcon=Búa til flýtileið á skjáborðinu
+Icelandic.ChocoInstall=Setja upp Chocolatey
 
 ; Italian
 Italian.InstallType=Tipo di installazione
@@ -111,6 +125,7 @@ Italian.PortInst=Esegui installazione portatile
 Italian.RegInst=Esegui installazione normale
 Italian.RegStartMmenuIcon=Crea una scorciatoia nel menu Start
 Italian.RegDesktopIcon=Crea una scorciatoia sul Desktop
+Italian.ChocoInstall=Installa Chocolatey
 
 ; Japanese
 Japanese.InstallType=インストールの種類
@@ -119,6 +134,7 @@ Japanese.PortInst=ポータブル インストールを実行する
 Japanese.RegInst=通常のインストールを実行します
 Japanese.RegStartMmenuIcon=スタート メニューにショートカットを作成する
 Japanese.RegDesktopIcon=デスクトップにショートカットを作成する
+Japanese.ChocoInstall=Chocolatey をインストールする
 
 ; Korean
 Korean.InstallType=설치 유형
@@ -127,6 +143,7 @@ Korean.PortInst=이동식 설치 수행
 Korean.RegInst=일반 설치 수행
 Korean.RegStartMmenuIcon=시작 메뉴에 바로가기 만들기
 Korean.RegDesktopIcon=바탕화면에 바로가기 생성
+Korean.ChocoInstall=초콜릿 설치
 
 ; Norwegian
 Norwegian.InstallType=Installasjonstype
@@ -135,6 +152,7 @@ Norwegian.PortInst=Utfør en bærbar installasjon
 Norwegian.RegInst=Utfør en vanlig installasjon
 Norwegian.RegStartMmenuIcon=Lag en snarvei på Start-menyen
 Norwegian.RegDesktopIcon=Lag en snarvei på skrivebordet
+Norwegian.ChocoInstall=Installer Chocolatey
 
 ; Polish
 Polish.InstallType=Typ instalacji
@@ -143,6 +161,7 @@ Polish.PortInst=Przeprowadź instalację przenośną
 Polish.RegInst=Przeprowadź zwykłą instalację
 Polish.RegStartMmenuIcon=Utwórz skrót w menu Start
 Polish.RegDesktopIcon=Utwórz skrót na pulpicie
+Polish.ChocoInstall=Zainstaluj Chocolatey
 
 ; Portuguese
 Portuguese.InstallType=Tipo de instalação
@@ -151,6 +170,7 @@ Portuguese.PortInst=Execute uma instalação portátil
 Portuguese.RegInst=Execute uma instalação regular
 Portuguese.RegStartMmenuIcon=Criar um atalho no menu Iniciar
 Portuguese.RegDesktopIcon=Criar um atalho na área de trabalho
+Portuguese.ChocoInstall=Instalar o Chocolatey
 
 ; Russian
 Russian.InstallType=Тип установки
@@ -159,6 +179,7 @@ Russian.PortInst=Выполнить переносную установку
 Russian.RegInst=Выполнить обычную установку
 Russian.RegStartMmenuIcon=Создать ярлык в меню «Пуск»
 Russian.RegDesktopIcon=Создать ярлык на рабочем столе
+Russian.ChocoInstall=Установить Chocolatey
 
 ; Slovenian
 Slovenian.InstallType=Vrsta namestitve
@@ -167,6 +188,7 @@ Slovenian.PortInst=Izvedite prenosno namestitev
 Slovenian.RegInst=Izvedite običajno namestitev
 Slovenian.RegStartMmenuIcon=Ustvarite bližnjico v meniju Start
 Slovenian.RegDesktopIcon=Ustvarite bližnjico na namizju
+Slovenian.ChocoInstall=Namesti Chocolatey
 
 ; Spanish
 Spanish.InstallType=Tipo de instalación
@@ -175,6 +197,7 @@ Spanish.PortInst=Realizar una instalación portátil
 Spanish.RegInst=Realizar una instalación regular
 Spanish.RegStartMmenuIcon=Crear un acceso directo en el menú Inicio
 Spanish.RegDesktopIcon=Crear un atajo en el escritorio
+Spanish.ChocoInstall=Instalar Chocolatey
 
 ; Turkish
 Turkish.InstallType=Yükleme türü
@@ -183,6 +206,7 @@ Turkish.PortInst=Taşınabilir bir kurulum gerçekleştirin
 Turkish.RegInst=Normal bir kurulum gerçekleştir
 Turkish.RegStartMmenuIcon=Başlat menüsünde bir kısayol oluştur
 Turkish.RegDesktopIcon=Masaüstünde bir kısayol oluştur
+Turkish.ChocoInstall=Chocolatey'i yükleyin
 
 ; Ukrainian
 Ukrainian.InstallType=Тип інсталяції
@@ -191,3 +215,4 @@ Ukrainian.PortInst=Виконати переносне встановлення
 Ukrainian.RegInst=Виконайте звичайну установку
 Ukrainian.RegStartMmenuIcon=Створити ярлик у меню «Пуск».
 Ukrainian.RegDesktopIcon=Створити ярлик на робочому столі
+Ukrainian.ChocoInstall=Встановити Chocolatey

--- a/WingetUI.iss
+++ b/WingetUI.iss
@@ -222,7 +222,7 @@ Name: "portableinstall"; Description: "{cm:PortInst}"; GroupDescription: "{cm:In
 Name: "regularinstall"; Description: "{cm:RegInst}"; GroupDescription: "{cm:InstallType}"; Flags: exclusive   
 Name: "regularinstall\startmenuicon"; Description: "{cm:RegStartMmenuIcon}"; GroupDescription: "{cm:ShCuts}"; 
 Name: "regularinstall\desktopicon"; Description: "{cm:RegDesktopIcon}"; GroupDescription: "{cm:ShCuts}";
-Name: "regularinstall\chocoinstall"; Description: "Install Chocolatey"; GroupDescription: "{cm:ShCuts}";
+Name: "regularinstall\chocoinstall"; Description: "{cm:ChocoInstall}"; GroupDescription: "{cm:ShCuts}";
 
 [Registry]
 Root: HKCU; Subkey: "SOFTWARE\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "WingetUI"; ValueData: """{app}\WingetUI.exe"" --daemon"; Flags: uninsdeletevalue; Tasks: regularinstall


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

- [x] **I have read the [contributing guidelines](https://github.com/marticliment/WingetUI/blob/main/CONTRIBUTING.md#coding), and I agree with the [Code of Conduct](https://github.com/marticliment/WingetUI/blob/main/CODE_OF_CONDUCT.md)**.
- [x] **Have you checked that there aren't other open [pull requests](https://github.com/marticliment/WingetUI/pulls) for the same changes?**
- [x] **Have you tested that the committed code can be executed without errors?**
- [x] **This PR is not composed of garbage changes used to farm GitHub activity to enter potential Crypto AirDrops.**
Any user suspected of farming GitHub activity with crypto purposes will get banned. Submitting broken code wastes the time of the contributors, who have to spend their free time reviewing, fixing, and testing code that does not even compile, breaks other features, or does not introduce any useful changes. Thank you for your understanding.

-----
**Add translation string in the installer ("Install Chocolatey")**
This proposal advocates including multilingual support in the installation process. Currently, the multilingual installer is missing the translation of the "Install Chocolatey" string.